### PR TITLE
Fix: set JAVA variable correctly if neither JAVA_HOME or JDK_HOME are set

### DIFF
--- a/mvnexec
+++ b/mvnexec
@@ -216,7 +216,7 @@ then
    setJavaExecutable "$JAVA_HOME"
 elif command -v java >&-
 then
-   JAVA=$(command -v java >&-)
+   JAVA=$(command -v java)
 else
    errorJavaExecutable
 fi


### PR DESCRIPTION
Previously this variable was set to nothing due to the removed part `>&-`, which resulted in an error when running, because the executable was empty.